### PR TITLE
Added support for qlot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.sx32fsl
 *.wx64fsl
 *.wx32fsl
+.qlot/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: run
 
-# If dependancies are not installed attempt to install them using
+# If dependencies are not installed attempt to install them using
 # the qlot executable
 .qlot/setup.lisp:
 	command -v qlot >/dev/null && qlot install

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-project = lisp
-
-all:run
+all: run
 
 # If dependancies are not installed attempt to install them using
 # the qlot executable
 .qlot/setup.lisp:
 	command -v qlot >/dev/null && qlot install
 
+.PHONY: run
 run: .qlot/setup.lisp
 	./scripts/run.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+project = lisp
+
+all:run
+
+# If dependancies are not installed attempt to install them using
+# the qlot executable
+.qlot/setup.lisp:
+	command -v qlot >/dev/null && qlot install
+
+run: .qlot/setup.lisp
+	./scripts/run.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # non-trivial-benchmarks
 Some Common lisp benchmarks (to compare libraries and techniques)
+
+# Setup
+If you would like to run or adapt the test suite it's best you use
+[qlot](https://github.com/fukamachi/qlot). Qlot provides a way for
+developers to ensure they have the library versions as the last time
+the tests where ran.
+
+## (Option 1) Roswell
+
+Installing qlot with roswell is as easy as
+
+```bash
+ros install qlot
+```
+
+Then ensure qlot is in your path
+
+Then install the dependancies using
+
+```bash
+qlot install
+```
+
+## (Option 2) Quicklisp
+
+Simply start up a repl at the root directory then in the repl run
+
+```lisp
+(ql:quickload :qlot)
+(qlot:install :non-trivial-benchmarks)
+```
+
+## Running the benchmark
+
+If the dependancies where installed correctly you can run the
+benchmarks by running `make` in the root directory.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ros install qlot
 
 Then ensure qlot is in your path
 
-Then install the dependancies using
+Then install the dependencies using
 
 ```bash
 qlot install
@@ -34,5 +34,5 @@ Simply start up a repl at the root directory then in the repl run
 
 ## Running the benchmark
 
-If the dependancies where installed correctly you can run the
+If the dependencies were installed correctly you can run the
 benchmarks by running `make` in the root directory.

--- a/qlfile
+++ b/qlfile
@@ -1,0 +1,7 @@
+ql log4cl
+ql trivial-benchmark
+ql alexandria
+ql eager-future2
+ql calispel
+ql lparallel
+ql green-threads

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,0 +1,32 @@
+("quicklisp" .
+ (:class qlot/source/dist:source-dist
+  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2022-02-20"))
+("log4cl" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("trivial-benchmark" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("alexandria" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("eager-future2" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("calispel" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("lparallel" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))
+("green-threads" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2022-02-20"))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-#
-# Install dependancies with qlot
-#
-qlot install || "please install qlot"
-

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Install dependancies with qlot
+#
+qlot install || "please install qlot"
+

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,6 +5,7 @@
 # This script serves has documentation more than anything.
 #
 
-sbcl --eval '(asdf:load-system :non-trivial-benchmarks)' \
+sbcl --load ".qlot/setup.lisp" \
+     --eval '(ql:quickload :non-trivial-benchmarks)' \
      --eval '(non-trivial-benchmarks:run)' \
      --quit


### PR DESCRIPTION
Added basic support for qlot. Left it open ended enough that we can support different lisps in the long run. I decided to add a makefile to avoid the headache of people running things in the wrong directory. I am open to dropping it if you feel make is an unnecessary dependency.